### PR TITLE
Fix Youtube streaming #149

### DIFF
--- a/Create-Release.ps1
+++ b/Create-Release.ps1
@@ -13,8 +13,8 @@ Write-Host "Building Espera..." -ForegroundColor Green
 
 Function GetMSBuildExe {
 	[CmdletBinding()]
-	$DotNetVersion = "4.0"
-	$RegKey = "HKLM:\software\Microsoft\MSBuild\ToolsVersions\$DotNetVersion"
+	$MSBuildToolsVersion = "14.0"
+	$RegKey = "HKLM:\software\Microsoft\MSBuild\ToolsVersions\$MSBuildToolsVersion"
 	$RegProperty = "MSBuildToolsPath"
 	$MSBuildExe = Join-Path -Path (Get-ItemProperty $RegKey).$RegProperty -ChildPath "msbuild.exe"
 	Return $MSBuildExe

--- a/Espera.Core.Tests/AudioPlayerTest.cs
+++ b/Espera.Core.Tests/AudioPlayerTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Reactive;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
@@ -29,7 +30,10 @@ namespace Espera.Core.Tests
         [Fact]
         public async Task StopsCurrentMediaPlayerWhenSwitchingAndPlaying()
         {
-            var audioPlayer = new AudioPlayer();
+            var streamProxy = Substitute.For<IHttpsProxyService>();
+            streamProxy.GetProxiedUri(new Uri("https://foobar.com")).ReturnsForAnyArgs(x => x.Args().First());
+
+            var audioPlayer = new AudioPlayer(streamProxy);
 
             var oldMediaPlayer = Substitute.For<IMediaPlayerCallback>();
             var newMediaPlayer = Substitute.For<IMediaPlayerCallback>();
@@ -56,7 +60,10 @@ namespace Espera.Core.Tests
             [Fact]
             public async Task DisposesCurrentAudioPlayerIfNewOneRegistered()
             {
-                var audioPlayer = new AudioPlayer();
+                var streamProxy = Substitute.For<IHttpsProxyService>();
+                streamProxy.GetProxiedUri(new Uri("https://foobar.com")).ReturnsForAnyArgs(x => x.Args().First());
+
+                var audioPlayer = new AudioPlayer(streamProxy);
 
                 var oldMediaPlayer = Substitute.For<IMediaPlayerCallback, IDisposable>();
                 var newMediaPlayer = Substitute.For<IMediaPlayerCallback, IDisposable>();
@@ -76,7 +83,10 @@ namespace Espera.Core.Tests
             [Fact]
             public async Task LoadsIntoAudioPlayerIfSongIsAudio()
             {
-                var audioPlayer = new AudioPlayer();
+                var streamProxy = Substitute.For<IHttpsProxyService>();
+                streamProxy.GetProxiedUri(new Uri("https://foobar.com")).ReturnsForAnyArgs(x => x.Args().First());
+
+                var audioPlayer = new AudioPlayer(streamProxy);
                 var mediaPlayerCallback = Substitute.For<IMediaPlayerCallback>();
                 audioPlayer.RegisterAudioPlayerCallback(mediaPlayerCallback);
 
@@ -91,7 +101,10 @@ namespace Espera.Core.Tests
             [Fact]
             public async Task LoadsIntoVideoPlayerIfSongIsVideo()
             {
-                var audioPlayer = new AudioPlayer();
+                var streamProxy = Substitute.For<IHttpsProxyService>();
+                streamProxy.GetProxiedUri(new Uri("https://foobar.com")).ReturnsForAnyArgs(x => x.Args().First());
+
+                var audioPlayer = new AudioPlayer(streamProxy);
                 var mediaPlayerCallback = Substitute.For<IMediaPlayerCallback>();
                 audioPlayer.RegisterVideoPlayerCallback(mediaPlayerCallback);
 
@@ -106,7 +119,10 @@ namespace Espera.Core.Tests
             [Fact]
             public async Task StopsCurrentPlayback()
             {
-                var audioPlayer = new AudioPlayer();
+                var streamProxy = Substitute.For<IHttpsProxyService>();
+                streamProxy.GetProxiedUri(new Uri("https://foobar.com")).ReturnsForAnyArgs(x => x.Args().First());
+
+                var audioPlayer = new AudioPlayer(streamProxy);
 
                 var states = audioPlayer.PlaybackState.CreateCollection();
 
@@ -128,7 +144,10 @@ namespace Espera.Core.Tests
             [Fact]
             public async Task DisposesDanglingAudioPlayer()
             {
-                var audioPlayer = new AudioPlayer();
+                var streamProxy = Substitute.For<IHttpsProxyService>();
+                streamProxy.GetProxiedUri(new Uri("https://foobar.com")).ReturnsForAnyArgs(x => x.Args().First());
+
+                var audioPlayer = new AudioPlayer(streamProxy);
                 var mediaPlayer = Substitute.For<IMediaPlayerCallback>();
                 audioPlayer.RegisterAudioPlayerCallback(mediaPlayer);
                 await audioPlayer.LoadAsync(Helpers.SetupSongMock());

--- a/Espera.Core.Tests/Espera.Core.Tests.csproj
+++ b/Espera.Core.Tests/Espera.Core.Tests.csproj
@@ -146,7 +146,7 @@
     <Compile Include="SoundCloudSongFinderTest.cs" />
     <Compile Include="SoundCloudSongTest.cs" />
     <Compile Include="TagSanitizerTest.cs" />
-    <Compile Include="HttpsProxyServiceTest.cs" />
+    <Compile Include="UriRewriteTest.cs" />
     <Compile Include="YoutubeSongFinderTest.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Espera.Core.Tests/Espera.Core.Tests.csproj
+++ b/Espera.Core.Tests/Espera.Core.Tests.csproj
@@ -46,11 +46,17 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Lager.0.4.2\lib\portable-net45+win+wpa81+wp80+MonoAndroid10+MonoTouch10\Lager.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Owin.Host.HttpListener, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.Host.HttpListener.3.0.1\lib\net45\Microsoft.Owin.Host.HttpListener.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.Reactive.Testing, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Rx-Testing.2.2.5\lib\net45\Microsoft.Reactive.Testing.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <Private>False</Private>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.8.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
@@ -140,6 +146,7 @@
     <Compile Include="SoundCloudSongFinderTest.cs" />
     <Compile Include="SoundCloudSongTest.cs" />
     <Compile Include="TagSanitizerTest.cs" />
+    <Compile Include="HttpsProxyServiceTest.cs" />
     <Compile Include="YoutubeSongFinderTest.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Espera.Core.Tests/Helpers.cs
+++ b/Espera.Core.Tests/Helpers.cs
@@ -7,6 +7,7 @@ using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 using System.Text;
 using System.Threading.Tasks;
+using Espera.Core.Audio;
 using Espera.Core.Management;
 using Espera.Core.Settings;
 using Microsoft.Reactive.Testing;
@@ -74,13 +75,14 @@ namespace Espera.Core.Tests
         }
 
         public static Library CreateLibrary(CoreSettings settings = null, ILibraryReader reader = null, ILibraryWriter writer = null,
-            IFileSystem fileSystem = null, ILocalSongFinder localSongFinder = null)
+            IFileSystem fileSystem = null, ILocalSongFinder localSongFinder = null, AudioPlayer audioPlayer = null)
         {
             return new LibraryBuilder().WithReader(reader)
                 .WithWriter(writer)
                 .WithSettings(settings)
                 .WithFileSystem(fileSystem)
                 .WithSongFinder(localSongFinder)
+                .WithAudioPlayer(audioPlayer)
                 .Build();
         }
 

--- a/Espera.Core.Tests/HttpsProxyServiceTest.cs
+++ b/Espera.Core.Tests/HttpsProxyServiceTest.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Net;
+using Espera.Core.Audio;
+using Xunit;
+
+namespace Espera.Core.Tests
+{
+    public class HttpsProxyServiceTest : IDisposable
+    {
+        private readonly IHttpsProxyService httpsProxyService;
+
+        public HttpsProxyServiceTest()
+        {
+            httpsProxyService = new HttpsProxyService();
+        }
+
+        [Fact]
+        public void YoutubeUrisAreProxied()
+        {
+           var song = new YoutubeSong("https://youtube.com", TimeSpan.Zero);
+           var path = song.GetType().GetField("playbackPath", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+           path.SetValue(song, "https://youtube.com/?a=c&");
+           var proxiedUri = song.GetSafePlaybackPath(httpsProxyService);
+           Assert.Equal("127.0.0.1", proxiedUri.Host);
+           Assert.Equal("/?remoteurl=" + WebUtility.UrlEncode("https://youtube.com/?a=c&"), proxiedUri.PathAndQuery);
+        }
+
+        [Fact]
+        public void SoundCloudUrisAreRewritten()
+        {
+            var song = new SoundCloudSong("https://soundcloud.com/foobar", "https://api.soundlcoud.com/foobar");
+            var safePath = song.GetSafePlaybackPath(httpsProxyService);
+            Assert.Equal("http://api.soundlcoud.com/foobar", safePath.ToString());
+        }
+
+
+        [Fact]
+        public void LocalUrisAreNotRewritten()
+        {
+            var song = new LocalSong("C:\\some\\file.mp3", TimeSpan.Zero);
+            Assert.Equal(new Uri("C:\\some\\file.mp3"), song.GetSafePlaybackPath(httpsProxyService));
+        }
+
+        [Fact]
+        public void ThrowsForNullUriObject()
+        {
+            var song = new YoutubeSong("https://youtube.com", TimeSpan.Zero);
+            Assert.Throws<ArgumentNullException>(() => song.GetSafePlaybackPath(null));
+        }
+
+
+        public void Dispose()
+        {
+            httpsProxyService.Dispose();
+        }
+    }
+}

--- a/Espera.Core.Tests/LibraryBuilder.cs
+++ b/Espera.Core.Tests/LibraryBuilder.cs
@@ -22,6 +22,7 @@ namespace Espera.Core.Tests
         private CoreSettings settings;
         private ILocalSongFinder songFinder;
         private ILibraryWriter writer;
+        private AudioPlayer audioPlayer;
 
         public Library Build()
         {
@@ -35,7 +36,8 @@ namespace Espera.Core.Tests
                 this.writer ?? Substitute.For<ILibraryWriter>(),
                 this.settings ?? new CoreSettings(new InMemoryBlobCache()),
                 this.fileSystem ?? new MockFileSystem(),
-                x => this.songFinder ?? SetupDefaultLocalSongFinder());
+                x => this.songFinder ?? SetupDefaultLocalSongFinder(),
+                this.audioPlayer ?? new AudioPlayer());
 
             Guid accessToken = library.LocalAccessControl.RegisterLocalAccessToken();
 
@@ -47,6 +49,12 @@ namespace Espera.Core.Tests
             library.RegisterAudioPlayerCallback(this.audioPlayerCallback ?? mediaPlayerCallback, accessToken);
 
             return library;
+        }
+
+        public LibraryBuilder WithAudioPlayer(AudioPlayer player)
+        {
+            this.audioPlayer = player;
+            return this;
         }
 
         public LibraryBuilder WithAudioPlayer(IMediaPlayerCallback player)

--- a/Espera.Core.Tests/LibraryTest.cs
+++ b/Espera.Core.Tests/LibraryTest.cs
@@ -26,9 +26,12 @@ namespace Espera.Core.Tests
         [Fact]
         public async Task CanPlayAWholeBunchOfSongs()
         {
+            var streamProxy = Substitute.For<IHttpsProxyService>();
+            streamProxy.GetProxiedUri(new Uri("https://foobar.com")).ReturnsForAnyArgs(x => x.Args().First());
+
             var song = new LocalSong("C://", TimeSpan.Zero);
 
-            using (Library library = new LibraryBuilder().WithPlaylist().Build())
+            using (Library library = new LibraryBuilder().WithPlaylist().WithAudioPlayer(new AudioPlayer(streamProxy)).Build())
             {
                 var awaiter = library.PlaybackState.Where(x => x == AudioPlayerState.Playing)
                     .Select((x, i) => i + 1)
@@ -231,9 +234,12 @@ namespace Espera.Core.Tests
             [Fact]
             public async Task CallsAudioPlayerPlay()
             {
+                var streamProxy = Substitute.For<IHttpsProxyService>();
+                streamProxy.GetProxiedUri(new Uri("https://foobar.com")).ReturnsForAnyArgs(x => x.Args().First());
+
                 var audioPlayerCallback = Substitute.For<IMediaPlayerCallback>();
 
-                using (Library library = new LibraryBuilder().WithPlaylist().WithAudioPlayer(audioPlayerCallback).Build())
+                using (Library library = new LibraryBuilder().WithPlaylist().WithAudioPlayer(audioPlayerCallback).WithAudioPlayer(new AudioPlayer(streamProxy)).Build())
                 {
                     Guid token = library.LocalAccessControl.RegisterLocalAccessToken();
 
@@ -427,7 +433,10 @@ namespace Espera.Core.Tests
                         }
                     }));
 
-                    using (Library library = new LibraryBuilder().WithPlaylist().WithAudioPlayer(audioPlayer).Build())
+                    var streamProxy = Substitute.For<IHttpsProxyService>();
+                    streamProxy.GetProxiedUri(new Uri("https://foobar.com")).ReturnsForAnyArgs(x => x.Args().First());
+
+                    using (Library library = new LibraryBuilder().WithPlaylist().WithAudioPlayer(audioPlayer).WithAudioPlayer(new AudioPlayer(streamProxy)).Build())
                     {
                         Song[] songs = Helpers.SetupSongMocks(2);
 
@@ -444,7 +453,10 @@ namespace Espera.Core.Tests
             [Fact]
             public async Task PlaysMultipleSongsInARow()
             {
-                using (Library library = Helpers.CreateLibrary())
+                var streamProxy = Substitute.For<IHttpsProxyService>();
+                streamProxy.GetProxiedUri(new Uri("https://foobar.com")).ReturnsForAnyArgs(x => x.Args().First());
+
+                using (Library library = Helpers.CreateLibrary(audioPlayer: new AudioPlayer(streamProxy)))
                 {
                     var conn = library.PlaybackState.Where(x => x == AudioPlayerState.Playing)
                         .Take(2)
@@ -460,9 +472,12 @@ namespace Espera.Core.Tests
             [Fact]
             public async Task SmokeTest()
             {
+                var streamProxy = Substitute.For<IHttpsProxyService>();
+                streamProxy.GetProxiedUri(new Uri("https://foobar.com")).ReturnsForAnyArgs(x => x.Args().First());
+
                 var audioPlayer = Substitute.For<IMediaPlayerCallback>();
 
-                using (Library library = new LibraryBuilder().WithAudioPlayer(audioPlayer).Build())
+                using (Library library = new LibraryBuilder().WithAudioPlayer(audioPlayer).WithAudioPlayer(new AudioPlayer(streamProxy)).Build())
                 {
                     Song song = Helpers.SetupSongMock();
 
@@ -541,7 +556,10 @@ namespace Espera.Core.Tests
             [Fact]
             public async Task PlaysNextSongAutomatically()
             {
-                using (Library library = new LibraryBuilder().WithPlaylist().Build())
+                var streamProxy = Substitute.For<IHttpsProxyService>();
+                streamProxy.GetProxiedUri(new Uri("https://foobar.com")).ReturnsForAnyArgs(x => x.Args().First());
+
+                using (Library library = new LibraryBuilder().WithPlaylist().WithAudioPlayer(new AudioPlayer(streamProxy)).Build())
                 {
                     Guid token = library.LocalAccessControl.RegisterLocalAccessToken();
 
@@ -564,7 +582,10 @@ namespace Espera.Core.Tests
                 var audioPlayerCallback = Substitute.For<IMediaPlayerCallback>();
                 audioPlayerCallback.LoadAsync(Arg.Any<Uri>()).Returns(Observable.Throw<Unit>(new SongLoadException()).ToTask());
 
-                using (Library library = new LibraryBuilder().WithPlaylist().WithAudioPlayer(audioPlayerCallback).Build())
+                var streamProxy = Substitute.For<IHttpsProxyService>();
+                streamProxy.GetProxiedUri(new Uri("https://foobar.com")).ReturnsForAnyArgs(x => x.Args().First());
+
+                using (Library library = new LibraryBuilder().WithPlaylist().WithAudioPlayer(audioPlayerCallback).WithAudioPlayer(new AudioPlayer(streamProxy)).Build())
                 {
                     Guid accessToken = library.LocalAccessControl.RegisterLocalAccessToken();
 
@@ -788,7 +809,10 @@ namespace Espera.Core.Tests
             [Fact]
             public async Task WhileSongIsPlayingStopsCurrentSong()
             {
-                using (Library library = new LibraryBuilder().WithPlaylist().Build())
+                var streamProxy = Substitute.For<IHttpsProxyService>();
+                streamProxy.GetProxiedUri(new Uri("https://foobar.com")).ReturnsForAnyArgs(x => x.Args().First());
+
+                using (Library library = new LibraryBuilder().WithPlaylist().WithAudioPlayer(new AudioPlayer(streamProxy)).Build())
                 {
                     Guid token = library.LocalAccessControl.RegisterLocalAccessToken();
 

--- a/Espera.Core.Tests/UriRewriteTest.cs
+++ b/Espera.Core.Tests/UriRewriteTest.cs
@@ -5,11 +5,11 @@ using Xunit;
 
 namespace Espera.Core.Tests
 {
-    public class HttpsProxyServiceTest : IDisposable
+    public class UriRewriteTest : IDisposable
     {
         private readonly IHttpsProxyService httpsProxyService;
 
-        public HttpsProxyServiceTest()
+        public UriRewriteTest()
         {
             httpsProxyService = new HttpsProxyService();
         }

--- a/Espera.Core.Tests/packages.config
+++ b/Espera.Core.Tests/packages.config
@@ -3,6 +3,7 @@
   <package id="akavache.core" version="4.1.2" targetFramework="net45" />
   <package id="Espera-Network" version="1.0.36" targetFramework="net45" />
   <package id="Lager" version="0.4.2" targetFramework="net45" />
+  <package id="Microsoft.Owin.Host.HttpListener" version="3.0.1" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net45" />
   <package id="NSubstitute" version="1.8.1.0" targetFramework="net45" />
   <package id="ReactiveMarrow" version="0.5.1" targetFramework="net45" />

--- a/Espera.Core/Espera.Core.csproj
+++ b/Espera.Core/Espera.Core.csproj
@@ -37,25 +37,45 @@
       <HintPath>..\packages\akavache.core.4.1.2\lib\net45\Akavache.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="BouncyCastle.Crypto, Version=1.7.4137.9688, Culture=neutral, PublicKeyToken=a4292a325f69b123, processorArchitecture=MSIL">
+      <HintPath>..\packages\BouncyCastle.1.7.0\lib\Net40-Client\BouncyCastle.Crypto.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Espera.Network, Version=1.0.36.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Espera-Network.1.0.36\lib\portable-net45+monoandroid+wpa81\Espera.Network.dll</HintPath>
     </Reference>
-    <Reference Include="Google.GData.Client, Version=2.2.0.0, Culture=neutral, PublicKeyToken=04a59ca9b0273830, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Google.GData.Client.2.2.0.0\lib\Google.GData.Client.dll</HintPath>
+    <Reference Include="Google.Apis, Version=1.13.1.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Apis.1.13.1\lib\net45\Google.Apis.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Google.GData.Extensions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=0b4c5df2ebf20876, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Google.GData.Extensions.2.2.0.0\lib\Google.GData.Extensions.dll</HintPath>
+    <Reference Include="Google.Apis.Auth, Version=1.13.1.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Apis.Auth.1.13.1\lib\net45\Google.Apis.Auth.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Google.GData.YouTube, Version=2.2.0.0, Culture=neutral, PublicKeyToken=af04a32718ae8833, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Google.GData.YouTube.2.2.0.0\lib\Google.GData.YouTube.dll</HintPath>
+    <Reference Include="Google.Apis.Auth.PlatformServices, Version=1.13.1.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Apis.Auth.1.13.1\lib\net45\Google.Apis.Auth.PlatformServices.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Google.Apis.Core, Version=1.13.1.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Apis.Core.1.13.1\lib\net45\Google.Apis.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Google.Apis.PlatformServices, Version=1.13.1.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Apis.1.13.1\lib\net45\Google.Apis.PlatformServices.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Google.Apis.YouTube.v3, Version=1.13.1.522, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Apis.YouTube.v3.1.13.1.522\lib\portable-net45+netcore45+wpa81+wp8\Google.Apis.YouTube.v3.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Lager, Version=0.4.2.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Lager.0.4.2\lib\portable-net45+win+wpa81+wp80+MonoAndroid10+MonoTouch10\Lager.dll</HintPath>
+    </Reference>
+    <Reference Include="log4net, Version=1.2.13.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <HintPath>..\packages\log4net.2.0.3\lib\net40-full\log4net.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="NAudio, Version=1.7.3.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -133,9 +153,13 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Xamarin.Insights.1.9.1.107\lib\portable-win+net40\Xamarin.Insights.dll</HintPath>
     </Reference>
-    <Reference Include="YoutubeExtractor, Version=0.10.6.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\YoutubeExtractor.0.10.6\lib\net35\YoutubeExtractor.dll</HintPath>
+    <Reference Include="YoutubeExtractor, Version=0.10.10.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\YoutubeExtractor.0.10.10\lib\net35\YoutubeExtractor.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Zlib.Portable, Version=1.11.0.0, Culture=neutral, PublicKeyToken=431cba815f6a8b5b, processorArchitecture=MSIL">
+      <HintPath>..\packages\Zlib.Portable.Signed.1.11.0\lib\portable-net4+sl5+wp8+win8+wpa81+MonoTouch+MonoAndroid\Zlib.Portable.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Espera.Core/Espera.Core.csproj
+++ b/Espera.Core/Espera.Core.csproj
@@ -77,12 +77,28 @@
       <HintPath>..\packages\log4net.2.0.3\lib\net40-full\log4net.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.Owin, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.3.0.1\lib\net45\Microsoft.Owin.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Host.HttpListener, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.Host.HttpListener.3.0.1\lib\net45\Microsoft.Owin.Host.HttpListener.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Hosting, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.Hosting.3.0.1\lib\net45\Microsoft.Owin.Hosting.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="NAudio, Version=1.7.3.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\NAudio.1.7.3\lib\net35\NAudio.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.8.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
+      <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="policy.2.0.taglib-sharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=db62eba44689b5b0, processorArchitecture=MSIL">
@@ -179,6 +195,8 @@
     <Compile Include="Audio\SongPreparationException.cs" />
     <Compile Include="Audio\IMediaPlayerCallback.cs" />
     <Compile Include="Audio\SongLoadException.cs" />
+    <Compile Include="HttpsProxyService.cs" />
+    <Compile Include="HttpsProxyMiddleware.cs" />
     <Compile Include="BlobCacheKeys.cs" />
     <Compile Include="IArtworkFetcher.cs" />
     <Compile Include="ILocalSongFinder.cs" />

--- a/Espera.Core/HttpsProxyMiddleware.cs
+++ b/Espera.Core/HttpsProxyMiddleware.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using Microsoft.Owin;
+using Owin;
+
+
+namespace Espera.Core
+{
+    public class Startup
+    {
+        public void Configuration(IAppBuilder app)
+        {
+            app.Use(typeof(HttpsProxyMiddleware));
+        }
+    }
+
+    public class HttpsProxyMiddleware : OwinMiddleware
+    {
+        public HttpsProxyMiddleware(OwinMiddleware next) : base(next)
+        {
+        }
+
+        public override async Task Invoke(IOwinContext ctx)
+        {
+            var url = ctx.Request.Query.Get("remoteurl");
+            var rangeHeader = ctx.Request.Headers.Get("Range");
+
+            //Reusing httpClient for multiple request does not work for some reason.
+            using (var httpClient = new HttpClient())
+            {
+                if (rangeHeader != null)
+                {
+                    httpClient.DefaultRequestHeaders.Range = RangeHeaderValue.Parse(rangeHeader);
+                }
+
+                try
+                {
+                    using (var remoteResponse = await httpClient.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, ctx.Request.CallCancelled))
+                    {
+                        if (remoteResponse.Content.Headers.ContentLength != null)
+                        {
+                            var remoteContentLength = remoteResponse.Content.Headers.ContentLength.Value;
+
+                            ctx.Response.StatusCode = rangeHeader != null ? 206 : 200;
+                            ctx.Response.Headers.Set("Content-Length", remoteContentLength.ToString());
+                            ctx.Response.Headers.Set("Accept-Ranges", "bytes");
+                            ctx.Response.ContentType = remoteResponse.Content.Headers.ContentType.ToString();
+
+                            if (remoteResponse.StatusCode < HttpStatusCode.OK || remoteResponse.StatusCode > HttpStatusCode.PartialContent)
+                            {
+                                ctx.Response.StatusCode = 500;
+                                return;
+                            }
+
+                            await StreamContent(ctx, url, httpClient, remoteResponse, remoteContentLength);
+                        }
+                    }
+                }
+                catch (Exception ex) when (ex is OperationCanceledException || ex is IOException)
+                {
+                    //IOExceptions/OperationCanceledException may occur if the client closes the connection.
+                }
+                finally
+                {
+                    ctx.Response.Body.Close();
+                }
+            }
+        }
+
+        private static async Task StreamContent(IOwinContext ctx, string url, HttpClient httpclient, HttpResponseMessage remoteResponse, long remoteContentLength)
+        {
+            using (var stream = await httpclient.GetStreamAsync(url))
+            {
+                var from = remoteResponse.Content?.Headers?.ContentRange?.From ?? 0;
+                var to = remoteContentLength - 1;
+                var responseContentRange = remoteResponse.Content?.Headers?.ContentRange?.ToString() ?? $"bytes {from}-{to}/{remoteContentLength}";
+
+                ctx.Response.Headers.Set("Content-Range", responseContentRange);
+
+                int length;
+                var bufferSize = 65536; //64KB
+                var buffer = new byte[bufferSize];
+                do
+                {
+                    length = await stream.ReadAsync(buffer, 0, bufferSize, ctx.Request.CallCancelled);
+                    await ctx.Response.Body.WriteAsync(buffer, 0, length, ctx.Request.CallCancelled);
+                } while (length > 0);
+            }
+        }
+    }
+}

--- a/Espera.Core/HttpsProxyService.cs
+++ b/Espera.Core/HttpsProxyService.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Net;
+using System.Net.Sockets;
+using Microsoft.Owin.Hosting;
+
+namespace Espera.Core
+{
+    public interface IHttpsProxyService : IDisposable
+    {
+        Uri GetProxiedUri(Uri remoteUri);
+    }
+
+    public class HttpsProxyService : IHttpsProxyService
+    {
+        private IDisposable host;
+        private readonly string hostUri;
+
+        public HttpsProxyService()
+        {
+            var port = GetFreeTcpPort();
+            hostUri = $"http://{IPAddress.Loopback}:{port}";
+            host = WebApp.Start<Startup>(hostUri);
+        }
+
+        public Uri GetProxiedUri(Uri uri)
+        {
+            if (uri == null)
+            {
+                throw new ArgumentNullException(nameof(uri));
+            }
+            if (uri.Scheme != Uri.UriSchemeHttps)
+            {
+                return uri;
+            }
+            return new Uri(hostUri + "/?remoteurl=" + WebUtility.UrlEncode(uri.ToString()));
+        }
+
+        private static int GetFreeTcpPort()
+        {
+            var tcpListener = new TcpListener(IPAddress.Loopback, 0);
+            tcpListener.Start();
+            var port = ((IPEndPoint)tcpListener.LocalEndpoint).Port;
+            tcpListener.Stop();
+#if DEBUG
+            return 8080;
+#endif
+            return port;
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                host?.Dispose();
+                host = null;
+            }
+        }
+    }
+}

--- a/Espera.Core/HttpsProxyService.cs
+++ b/Espera.Core/HttpsProxyService.cs
@@ -44,7 +44,9 @@ namespace Espera.Core
 #if DEBUG
             return 8080;
 #endif
+#pragma warning disable 162
             return port;
+#pragma warning restore 162
         }
 
         public void Dispose()

--- a/Espera.Core/ISoundCloudApi.cs
+++ b/Espera.Core/ISoundCloudApi.cs
@@ -10,7 +10,7 @@ namespace Espera.Core
         IObservable<ExploreResponse> GetPopularTracks(int limit);
 
         [Get("/tracks.json")]
-        IObservable<IReadOnlyList<SoundCloudSong>> Search([AliasAs("q")] string searchTerm, [AliasAs("client_id")] string clientId);
+        IObservable<IReadOnlyList<SoundCloudSong>> Search([AliasAs("q")] string searchTerm, [AliasAs("client_id")] string clientId, byte limit);
     }
 
     public class ExploreResponse

--- a/Espera.Core/Management/Library.cs
+++ b/Espera.Core/Management/Library.cs
@@ -49,7 +49,7 @@ namespace Espera.Core.Management
         private string songSourcePath;
 
         public Library(ILibraryReader libraryReader, ILibraryWriter libraryWriter, CoreSettings settings,
-            IFileSystem fileSystem, Func<string, ILocalSongFinder> localSongFinderFunc = null)
+            IFileSystem fileSystem, Func<string, ILocalSongFinder> localSongFinderFunc = null, AudioPlayer audioPlayer = null)
         {
             if (libraryReader == null)
                 throw new ArgumentNullException("libraryReader");
@@ -75,7 +75,7 @@ namespace Espera.Core.Management
             this.songs = new HashSet<LocalSong>();
             this.playlists = new ReactiveList<Playlist>();
             this.songsUpdated = new Subject<Unit>();
-            this.audioPlayer = new AudioPlayer();
+            this.audioPlayer = audioPlayer ?? new AudioPlayer();
             this.manualUpdateTrigger = new Subject<Unit>();
 
             this.LoadedSong = this.audioPlayer.LoadedSong;

--- a/Espera.Core/Song.cs
+++ b/Espera.Core/Song.cs
@@ -5,6 +5,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
+using Espera.Core.Audio;
 
 namespace Espera.Core
 {
@@ -152,6 +153,11 @@ namespace Espera.Core
             }
 
             return changed;
+        }
+
+        public virtual Uri GetSafePlaybackPath(IHttpsProxyService proxyService)
+        {
+            return new Uri(PlaybackPath);
         }
 
         /// <summary>

--- a/Espera.Core/SoundCloudSong.cs
+++ b/Espera.Core/SoundCloudSong.cs
@@ -1,6 +1,7 @@
 using Espera.Network;
 using Newtonsoft.Json;
 using System;
+using Espera.Core.Audio;
 
 namespace Espera.Core
 {
@@ -103,6 +104,11 @@ namespace Espera.Core
                 this.user = value;
                 this.Artist = value == null ? string.Empty : value.Username;
             }
+        }
+
+        public override Uri GetSafePlaybackPath(IHttpsProxyService proxyService)
+        {
+            return new Uri(PlaybackPath.Replace("https://", "http://"));
         }
     }
 

--- a/Espera.Core/SoundCloudSongFinder.cs
+++ b/Espera.Core/SoundCloudSongFinder.cs
@@ -53,7 +53,7 @@ namespace Espera.Core
 
         private static IObservable<IReadOnlyList<SoundCloudSong>> SearchSongs(string searchTerm)
         {
-            return RestService.For<ISoundCloudApi>("http://api.soundcloud.com").Search(searchTerm, ClientId);
+            return RestService.For<ISoundCloudApi>("https://api.soundcloud.com").Search(searchTerm, ClientId);
         }
 
         private static void SetupSongUrls(IEnumerable<SoundCloudSong> songs)

--- a/Espera.Core/SoundCloudSongFinder.cs
+++ b/Espera.Core/SoundCloudSongFinder.cs
@@ -53,7 +53,7 @@ namespace Espera.Core
 
         private static IObservable<IReadOnlyList<SoundCloudSong>> SearchSongs(string searchTerm)
         {
-            return RestService.For<ISoundCloudApi>("https://api.soundcloud.com").Search(searchTerm, ClientId);
+            return RestService.For<ISoundCloudApi>("https://api.soundcloud.com").Search(searchTerm, ClientId, 200);
         }
 
         private static void SetupSongUrls(IEnumerable<SoundCloudSong> songs)

--- a/Espera.Core/YoutubeSong.cs
+++ b/Espera.Core/YoutubeSong.cs
@@ -55,7 +55,11 @@ namespace Espera.Core
         /// <summary>
         /// Gets or sets the average rating.
         /// </summary>
+        /// <remarks>
+        /// Obsolete because Youtube API v3 does not longer provide a rating.
+        /// </remarks>
         /// <value>The average rating. <c>null</c> , if the rating is unknown.</value>
+        [Obsolete]
         public double? Rating { get; set; }
 
         /// <summary>

--- a/Espera.Core/YoutubeSong.cs
+++ b/Espera.Core/YoutubeSong.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
+using Espera.Core.Audio;
 using YoutubeExtractor;
 
 namespace Espera.Core
@@ -52,15 +53,6 @@ namespace Espera.Core
             get { return this.playbackPath; }
         }
 
-        /// <summary>
-        /// Gets or sets the average rating.
-        /// </summary>
-        /// <remarks>
-        /// Obsolete because Youtube API v3 does not longer provide a rating.
-        /// </remarks>
-        /// <value>The average rating. <c>null</c> , if the rating is unknown.</value>
-        [Obsolete]
-        public double? Rating { get; set; }
 
         /// <summary>
         /// Gets or sets the thumbnail source.
@@ -186,6 +178,15 @@ namespace Espera.Core
             string regexSearch = new string(Path.GetInvalidFileNameChars()) + new string(Path.GetInvalidPathChars());
             var r = new Regex(string.Format("[{0}]", Regex.Escape(regexSearch)));
             return r.Replace(path, "");
+        }
+
+        public override Uri GetSafePlaybackPath(IHttpsProxyService proxyService)
+        {
+            if (proxyService == null)
+            {
+                throw new ArgumentNullException(nameof(proxyService));
+            }
+            return proxyService.GetProxiedUri(new Uri(playbackPath));
         }
     }
 }

--- a/Espera.Core/packages.config
+++ b/Espera.Core/packages.config
@@ -9,8 +9,12 @@
   <package id="Google.Apis.YouTube.v3" version="1.13.1.522" targetFramework="net45" />
   <package id="Lager" version="0.4.2" targetFramework="net45" />
   <package id="log4net" version="2.0.3" targetFramework="net45" />
+  <package id="Microsoft.Owin" version="3.0.1" targetFramework="net45" />
+  <package id="Microsoft.Owin.Host.HttpListener" version="3.0.1" targetFramework="net45" />
+  <package id="Microsoft.Owin.Hosting" version="3.0.1" targetFramework="net45" />
   <package id="NAudio" version="1.7.3" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net45" />
+  <package id="Owin" version="1.0" targetFramework="net45" />
   <package id="Punchclock" version="1.2.0" targetFramework="net45" />
   <package id="Rareform" version="1.5.2" targetFramework="net45" />
   <package id="ReactiveMarrow" version="0.5.1" targetFramework="net45" />

--- a/Espera.Core/packages.config
+++ b/Espera.Core/packages.config
@@ -1,11 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="akavache.core" version="4.1.2" targetFramework="net45" />
+  <package id="BouncyCastle" version="1.7.0" targetFramework="net45" />
   <package id="Espera-Network" version="1.0.36" targetFramework="net45" />
-  <package id="Google.GData.Client" version="2.2.0.0" targetFramework="net45" />
-  <package id="Google.GData.Extensions" version="2.2.0.0" targetFramework="net45" />
-  <package id="Google.GData.YouTube" version="2.2.0.0" targetFramework="net45" />
+  <package id="Google.Apis" version="1.13.1" targetFramework="net45" />
+  <package id="Google.Apis.Auth" version="1.13.1" targetFramework="net45" />
+  <package id="Google.Apis.Core" version="1.13.1" targetFramework="net45" />
+  <package id="Google.Apis.YouTube.v3" version="1.13.1.522" targetFramework="net45" />
   <package id="Lager" version="0.4.2" targetFramework="net45" />
+  <package id="log4net" version="2.0.3" targetFramework="net45" />
   <package id="NAudio" version="1.7.3" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net45" />
   <package id="Punchclock" version="1.2.0" targetFramework="net45" />
@@ -24,5 +27,6 @@
   <package id="System.IO.Abstractions" version="2.0.0.124" targetFramework="net45" />
   <package id="taglib" version="2.1.0.0" targetFramework="net45" />
   <package id="Xamarin.Insights" version="1.9.1.107" targetFramework="net45" />
-  <package id="YoutubeExtractor" version="0.10.6" targetFramework="net45" />
+  <package id="YoutubeExtractor" version="0.10.10" targetFramework="net45" />
+  <package id="Zlib.Portable.Signed" version="1.11.0" targetFramework="net45" />
 </packages>

--- a/Espera.View/AppBootstrapper.cs
+++ b/Espera.View/AppBootstrapper.cs
@@ -23,6 +23,7 @@ using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Windows;
 using System.Windows.Threading;
+using Espera.Core.Audio;
 
 namespace Espera.View
 {
@@ -72,6 +73,8 @@ namespace Espera.View
             Locator.CurrentMutable.RegisterLazySingleton(() => new SQLitePersistentBlobCache(Path.Combine(AppInfo.BlobCachePath, "api-requests.cache.db")),
                 typeof(IBlobCache), BlobCacheKeys.RequestCacheContract);
 
+            Locator.CurrentMutable.RegisterLazySingleton(() => new HttpsProxyService(), typeof(IHttpsProxyService));
+
             Locator.CurrentMutable.RegisterLazySingleton(() =>
                 new ShellViewModel(Locator.Current.GetService<Library>(),
                     this.viewSettings, this.coreSettings,
@@ -98,6 +101,9 @@ namespace Espera.View
 
             this.Log().Info("Shutting down the library");
             Locator.Current.GetService<Library>().Dispose();
+
+            this.Log().Info("Shutting down OWIN host");
+            Locator.Current.GetService<IHttpsProxyService>().Dispose();
 
             this.Log().Info("Shutting down BlobCaches");
             BlobCache.Shutdown().Wait();

--- a/Espera.View/Espera.View.csproj
+++ b/Espera.View/Espera.View.csproj
@@ -199,9 +199,9 @@
     <Reference Include="WindowsBase" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
-    <Reference Include="YoutubeExtractor, Version=0.10.6.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\YoutubeExtractor.0.10.6\lib\net35\YoutubeExtractor.dll</HintPath>
+    <Reference Include="YoutubeExtractor, Version=0.10.10.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\YoutubeExtractor.0.10.10\lib\net35\YoutubeExtractor.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Espera.View/Espera.View.csproj
+++ b/Espera.View/Espera.View.csproj
@@ -93,6 +93,10 @@
       <HintPath>..\packages\MahApps.Metro.1.2.4.0\lib\net45\MahApps.Metro.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.Owin.Host.HttpListener, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.Host.HttpListener.3.0.1\lib\net45\Microsoft.Owin.Host.HttpListener.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.Web.XmlTransform">
       <HintPath>..\packages\Microsoft.Web.Xdt.2.1.1\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
     </Reference>

--- a/Espera.View/SortHelpers.cs
+++ b/Espera.View/SortHelpers.cs
@@ -45,12 +45,6 @@ namespace Espera.View
                 .OrderBy(song => song.PlaybackCount, sortOrder);
         }
 
-        public static Func<IEnumerable<YoutubeSongViewModel>, IOrderedEnumerable<YoutubeSongViewModel>> GetOrderByRating(SortOrder sortOrder)
-        {
-            return songs => songs
-                .OrderBy(song => song.Rating, sortOrder);
-        }
-
         public static Func<IEnumerable<T>, IOrderedEnumerable<T>> GetOrderByTitle<T>(SortOrder sortOrder) where T : ISongViewModelBase
         {
             return songs => songs

--- a/Espera.View/ViewModels/YoutubeSongViewModel.cs
+++ b/Espera.View/ViewModels/YoutubeSongViewModel.cs
@@ -225,14 +225,11 @@ namespace Espera.View.ViewModels
 
         private async Task GetThumbnailAsync()
         {
-            Uri thumbnailUrl = ((YoutubeSong)this.Model).ThumbnailSource;
-            thumbnailUrl = new Uri(thumbnailUrl.ToString().Replace("default", "hqdefault"));
-
             this.IsLoadingThumbnail = true;
 
             try
             {
-                IBitmap image = await BlobCache.LocalMachine.LoadImageFromUrl(thumbnailUrl.ToString(), absoluteExpiration: DateTimeOffset.Now + TimeSpan.FromMinutes(60));
+                IBitmap image = await BlobCache.LocalMachine.LoadImageFromUrl(((YoutubeSong)this.Model).ThumbnailSource.ToString(), absoluteExpiration: DateTimeOffset.Now + TimeSpan.FromMinutes(60));
 
                 this.Thumbnail = image.ToNative();
             }

--- a/Espera.View/ViewModels/YoutubeSongViewModel.cs
+++ b/Espera.View/ViewModels/YoutubeSongViewModel.cs
@@ -112,6 +112,7 @@ namespace Espera.View.ViewModels
             private set { this.RaiseAndSetIfChanged(ref this.isLoadingThumbnail, value); }
         }
 
+        [Obsolete]
         public double? Rating
         {
             get { return ((YoutubeSong)this.Model).Rating; }

--- a/Espera.View/ViewModels/YoutubeSongViewModel.cs
+++ b/Espera.View/ViewModels/YoutubeSongViewModel.cs
@@ -112,12 +112,6 @@ namespace Espera.View.ViewModels
             private set { this.RaiseAndSetIfChanged(ref this.isLoadingThumbnail, value); }
         }
 
-        [Obsolete]
-        public double? Rating
-        {
-            get { return ((YoutubeSong)this.Model).Rating; }
-        }
-
         public ImageSource Thumbnail
         {
             get

--- a/Espera.View/ViewModels/YoutubeViewModel.cs
+++ b/Espera.View/ViewModels/YoutubeViewModel.cs
@@ -12,7 +12,6 @@ namespace Espera.View.ViewModels
     public class YoutubeViewModel : NetworkSongViewModel<YoutubeSongViewModel, YoutubeSong>
     {
         private readonly ViewSettings viewSettings;
-        private SortOrder ratingOrder;
         private SortOrder viewsOrder;
 
         public YoutubeViewModel(Library library, ViewSettings viewSettings, CoreSettings coreSettings, Guid accessToken, IYoutubeSongFinder songFinder = null)
@@ -24,9 +23,6 @@ namespace Espera.View.ViewModels
                 Throw.ArgumentNullException(() => viewSettings);
 
             this.viewSettings = viewSettings;
-
-            this.OrderByRatingCommand = ReactiveCommand.Create();
-            this.OrderByRatingCommand.Subscribe(_ => this.ApplyOrder(SortHelpers.GetOrderByRating, ref this.ratingOrder));
 
             this.OrderByViewsCommand = ReactiveCommand.Create();
             this.OrderByViewsCommand.Subscribe(_ => this.ApplyOrder(SortHelpers.GetOrderByViews, ref this.viewsOrder));
@@ -44,15 +40,7 @@ namespace Espera.View.ViewModels
             set { this.viewSettings.YoutubeLinkColumnWidth = value; }
         }
 
-        public ReactiveCommand<object> OrderByRatingCommand { get; private set; }
-
         public ReactiveCommand<object> OrderByViewsCommand { get; private set; }
-
-        public int RatingColumnWidth
-        {
-            get { return this.viewSettings.YoutubeRatingColumnWidth; }
-            set { this.viewSettings.YoutubeRatingColumnWidth = value; }
-        }
 
         public int TitleColumnWidth
         {

--- a/Espera.View/ViewSettings.cs
+++ b/Espera.View/ViewSettings.cs
@@ -112,12 +112,6 @@ namespace Espera.View
             set { this.SetOrCreate(value); }
         }
 
-        public int YoutubeRatingColumnWidth
-        {
-            get { return this.GetOrCreate(75); }
-            set { this.SetOrCreate(value); }
-        }
-
         public int YoutubeTitleColumnWidth
         {
             get { return this.GetOrCreate(200); }

--- a/Espera.View/Views/YoutubeView.xaml
+++ b/Espera.View/Views/YoutubeView.xaml
@@ -144,14 +144,6 @@
                             </DataTemplate>
                         </GridViewColumn.CellTemplate>
                     </GridViewColumn>
-                    <GridViewColumn Width="{Binding Path=RatingColumnWidth, Mode=TwoWay}">
-                        <GridViewColumnHeader Command="{Binding Path=OrderByRatingCommand}" Content="Rating" />
-                        <GridViewColumn.CellTemplate>
-                            <DataTemplate>
-                                <TextBlock Text="{Binding Path=Rating, StringFormat=\{0:0.0\}, TargetNullValue=n/a}" TextTrimming="CharacterEllipsis" />
-                            </DataTemplate>
-                        </GridViewColumn.CellTemplate>
-                    </GridViewColumn>
                     <GridViewColumn Width="{Binding Path=ViewsColumnWidth, Mode=TwoWay}">
                         <GridViewColumnHeader Command="{Binding Path=OrderByViewsCommand}" Content="Views" />
                         <GridViewColumn.CellTemplate>

--- a/Espera.View/WpfMediaPlayer.cs
+++ b/Espera.View/WpfMediaPlayer.cs
@@ -32,11 +32,7 @@ namespace Espera.View
 
         public Task LoadAsync(Uri uri)
         {
-            // MediaElement is too dumb to accept https urls, so try to remove it
-            // https: //connect.microsoft.com/VisualStudio/feedback/details/934355/in-a-wpf-standalone-application-exe-when-the-source-of-a-mediaelement-is-set-to-a-https-uri-it-throws-a-nullreferenceexception
-            var strippedHttp = new Uri(uri.ToString().Replace("https://", "http://"));
-
-            return this.mediaElement.Dispatcher.InvokeAsync(() => this.mediaElement.Source = strippedHttp).Task;
+            return this.mediaElement.Dispatcher.InvokeAsync(() => this.mediaElement.Source = uri).Task;
         }
 
         public Task PauseAsync()

--- a/Espera.View/packages.config
+++ b/Espera.View/packages.config
@@ -10,6 +10,7 @@
   <package id="GlobalHotKey" version="1.1.0" targetFramework="net45" />
   <package id="Lager" version="0.4.2" targetFramework="net45" />
   <package id="MahApps.Metro" version="1.2.4.0" targetFramework="net45" />
+  <package id="Microsoft.Owin.Host.HttpListener" version="3.0.1" targetFramework="net45" />
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net45" />
   <package id="Mono.Cecil" version="0.9.5.4" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net45" />

--- a/Espera.View/packages.config
+++ b/Espera.View/packages.config
@@ -32,5 +32,5 @@
   <package id="squirrel.windows" version="0.9.3" targetFramework="net45" />
   <package id="System.IO.Abstractions" version="2.0.0.124" targetFramework="net45" />
   <package id="System.IO.Abstractions.TestingHelpers" version="2.0.0.124" targetFramework="net45" />
-  <package id="YoutubeExtractor" version="0.10.6" targetFramework="net45" />
+  <package id="YoutubeExtractor" version="0.10.10" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
## Changes concerning #149
- Katana host as a local proxy, providing MediaElement with a HTTP stream. For the time beeing it is only used for Youtube but could be used for Soundcloud as well if they decide to enforce transport encryption too.
- Updated Youtube API libs.
- Removed Youtube rating as ratings are no longer provided by the Youtube API.
- Changed the way URLs are customized. Each sub type of `Song` is responsible for customising it's own URL while only the proxy can create proxy URLs.
## Minor changes concerning the Soundcloud API
- Set the limit for the Soundcloud API search to 200. This is the maximum Soundcloud allows. If the limit is omitted, results are truncated after the 10th hit.
- Soundcloud API changed from HTTP to HTTPS as the secure version is orders of magnitudes faster for me
## Known issues
- **#152 is not fixed, you will need to provide a new Youtube API key**
- #155 Youtube video streaming does not work yet (I have little interest in working on it)
