### PR TITLE
Fix V3019

### DIFF
--- a/Espera.View/DragDropExtension.cs
+++ b/Espera.View/DragDropExtension.cs
@@ -86,7 +86,7 @@ namespace Espera.View
         {
             FrameworkElement container = d as FrameworkElement;
 
-            if (d == null)
+            if (container == null)
             {
                 Debug.Fail("Invalid type!");
                 return;


### PR DESCRIPTION
Hello! I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio:

- Possibly an incorrect variable is compared to null after type conversion using 'as' keyword. Check variables 'd', 'container'. Espera.View DragDropExtension.cs 89