### PR TITLE
Fix V3118

### DIFF
--- a/Espera.View/DragDropExtension.cs
+++ b/Espera.View/DragDropExtension.cs
@@ -113,7 +113,7 @@ namespace Espera.View
             // restrict to scroll at two places at a time (how would that go anyways) but only syncs
             // them in time.... that's fair enough; (300ms for ListBox, 20ms for Content)
             TimeSpan span = DateTime.UtcNow - s_lastTime;
-            if (span.Milliseconds < (itemwise ? 300 : 20))
+            if (span.TotalMilliseconds < (itemwise ? 300 : 20))
                 return;
             s_lastTime = DateTime.UtcNow;
 


### PR DESCRIPTION
Hello again from Pinguem.ru competition on finding errors. I found some more bugs with PVS-Studio:

- Milliseconds component of 'span' is used, which does not represent full time interval. Possibly 'TotalMilliseconds' value was intended instead. Espera.View DragDropExtension.cs 116